### PR TITLE
Linkify changelists

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
@@ -34,6 +34,7 @@ public class DiscordPipelineStep extends AbstractStepImpl {
     private boolean unstable;
     private boolean enableArtifactsList;
     private boolean showChangeset;
+    private String scmWebUrl;
 
     @DataBoundConstructor
     public DiscordPipelineStep(String webhookURL) {
@@ -152,6 +153,15 @@ public class DiscordPipelineStep extends AbstractStepImpl {
         return showChangeset;
     }
 
+    @DataBoundSetter
+    public void setScmWebUrl(String url) {
+        this.scmWebUrl = url;
+    }
+
+    public String getScmWebUrl() {
+        return scmWebUrl;
+    }
+
     public static class DiscordPipelineStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
         @Inject
         transient DiscordPipelineStep step;
@@ -189,8 +199,8 @@ public class DiscordPipelineStep extends AbstractStepImpl {
             if (step.getEnableArtifactsList() || step.getShowChangeset()) {
                 JenkinsLocationConfiguration globalConfig = JenkinsLocationConfiguration.get();
                 Run build = getContext().get(Run.class);
-                wh.setDescription(new EmbedDescription(build, globalConfig, step.getDescription(), step.getEnableArtifactsList(), step.getShowChangeset())
-                            .toString()
+                wh.setDescription(new EmbedDescription(build, globalConfig, step.getDescription(), step.getEnableArtifactsList(), step.getShowChangeset(), step.getScmWebUrl())
+                        .toString()
                 );
             } else {
                 wh.setDescription(checkLimitAndTruncate("description", step.getDescription(), DESCRIPTION_LIMIT));

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -44,7 +44,8 @@ public class WebhookPublisher extends Notifier {
     private boolean sendLogFile;
     private boolean sendStartNotification;
     private static final String NAME = "Discord Notifier";
-    private static final String VERSION = "1.4.14";
+    private static final String VERSION = "1.4.11";
+    private final String scmWebUrl;
 
     @DataBoundConstructor
     public WebhookPublisher(
@@ -61,7 +62,8 @@ public class WebhookPublisher extends Notifier {
             boolean enableFooterInfo,
             boolean showChangeset,
             boolean sendLogFile,
-            boolean sendStartNotification
+            boolean sendStartNotification,
+            String scmWebUrl
     ) {
         this.webhookURL = webhookURL;
         this.thumbnailURL = thumbnailURL;
@@ -77,6 +79,7 @@ public class WebhookPublisher extends Notifier {
         this.customUsername = customUsername;
         this.sendLogFile = sendLogFile;
         this.sendStartNotification = sendStartNotification;
+        this.scmWebUrl = scmWebUrl;
     }
 
     public String getWebhookURL() {
@@ -135,6 +138,10 @@ public class WebhookPublisher extends Notifier {
         return this.sendStartNotification;
     }
 
+    public String getScmWebUrl() {
+        return this.scmWebUrl;
+    }
+
     @Override
     public boolean needsToRunAfterFinalized() {
         return true;
@@ -172,7 +179,7 @@ public class WebhookPublisher extends Notifier {
                             + "**Build:** "
                             + build.getId();
                 }
-                wh.setDescription(new EmbedDescription(build, globalConfig, description, false, false).toString());
+                wh.setDescription(new EmbedDescription(build, globalConfig, description, false, false, null).toString());
                 wh.send();
             } catch (WebhookException | InterruptedException | IOException e1) {
                 e1.printStackTrace(listener.getLogger());
@@ -280,7 +287,7 @@ public class WebhookPublisher extends Notifier {
 
         wh.setThumbnail(thumbnailURL);
         wh.setDescription(
-                new EmbedDescription(build, globalConfig, descriptionPrefix, this.enableArtifactList, this.showChangeset)
+                new EmbedDescription(build, globalConfig, descriptionPrefix, this.enableArtifactList, this.showChangeset, this.scmWebUrl)
                         .toString()
         );
         wh.setStatus(statusColor);

--- a/src/main/resources/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep/config.jelly
+++ b/src/main/resources/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep/config.jelly
@@ -30,4 +30,7 @@
   <f:entry title="Show Changeset" field="showChangeset">
     <f:checkbox />
   </f:entry>
+  <f:entry title="SCM Web URL" field="scmWebUrl">
+    <f:textbox />
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Add an option to specify a format string to turn changelist items into clickable links. For example
```Groovy
discordSend(
	webhookURL: DISCORD_WEBHOOK_URL,
	showChangeset: true,
	scmWebUrl: 'https://project.dev/hg/stuff/rev/%s?arg=val')
```
will result in something like
![image](https://user-images.githubusercontent.com/2499652/107853955-05793780-6e19-11eb-9a59-cd44c019e4eb.png)
where the blue stuff is clickable and will lead to a web view of the commit.