### PR TITLE
Pipeline step can set custom username & avatar url (or use discord default)

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
@@ -222,10 +222,10 @@ public class DiscordPipelineStep extends AbstractStepImpl {
             wh.setContent(step.getNotes());
             
             if (step.getCustomAvatarUrl() != null)
-				wh.setCustomAvatarUrl(step.getCustomAvatarUrl());
-				
-			if (step.getCustomUsername() != null)
-				wh.setCustomUsername(step.getCustomUsername());
+                wh.setCustomAvatarUrl(step.getCustomAvatarUrl());
+                
+            if (step.getCustomUsername() != null)
+                wh.setCustomUsername(step.getCustomUsername());
 
             try { wh.send(); }
             catch (WebhookException e) { e.printStackTrace(listener.getLogger()); }

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
@@ -30,6 +30,8 @@ public class DiscordPipelineStep extends AbstractStepImpl {
     private String thumbnail;
     private String result;
     private String notes;
+    private String customAvatarUrl;
+    private String customUsername;
     private boolean successful;
     private boolean unstable;
     private boolean enableArtifactsList;
@@ -133,6 +135,24 @@ public class DiscordPipelineStep extends AbstractStepImpl {
     public String getNotes() {
         return notes;
     }
+    
+    @DataBoundSetter
+    public void setCustomAvatarUrl(String customAvatarUrl) {
+        this.customAvatarUrl = customAvatarUrl;
+    }
+
+    public String getCustomAvatarUrl() {
+        return customAvatarUrl;
+    }
+    
+    @DataBoundSetter
+    public void setCustomUsername(String customUsername) {
+        this.customUsername = customUsername;
+    }
+
+    public String getCustomUsername() {
+        return customUsername;
+    }
 
     @DataBoundSetter
     public void setEnableArtifactsList(boolean enable) {
@@ -200,6 +220,12 @@ public class DiscordPipelineStep extends AbstractStepImpl {
             wh.setFooter(checkLimitAndTruncate("footer", step.getFooter(), FOOTER_LIMIT));
             wh.setStatus(statusColor);
             wh.setContent(step.getNotes());
+            
+            if (step.getCustomAvatarUrl() != null)
+				wh.setCustomAvatarUrl(step.getCustomAvatarUrl());
+				
+			if (step.getCustomUsername() != null)
+				wh.setCustomUsername(step.getCustomUsername());
 
             try { wh.send(); }
             catch (WebhookException e) { e.printStackTrace(listener.getLogger()); }

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
@@ -78,24 +78,24 @@ class DiscordWebhook {
     }
 
     public DiscordWebhook setCustomUsername(String username) {
-		if (username != null && !username.equals(""))
-			this.obj.put("username", username);
-		else
-		{
-			// unset will allow default discord username to be used (as specified in discord's integration settings)
-			this.obj.remove("username"); 
-		}
+        if (username != null && !username.equals(""))
+            this.obj.put("username", username);
+        else
+        {
+            // unset will allow default discord username to be used (as specified in discord's integration settings)
+            this.obj.remove("username"); 
+        }
         return this;
     }
 
     public DiscordWebhook setCustomAvatarUrl(String url) {
-		if (url != null && !url.equals(""))
-			this.obj.put("avatar_url", url);
-		else
-		{
-			// unset will allow default avatar to be used (as specified in discord's integration settings)
-			this.obj.remove("avatar_url"); 
-		}
+        if (url != null && !url.equals(""))
+            this.obj.put("avatar_url", url);
+        else
+        {
+            // unset will allow default avatar to be used (as specified in discord's integration settings)
+            this.obj.remove("avatar_url"); 
+        }
         return this;
     }
 

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
@@ -78,12 +78,24 @@ class DiscordWebhook {
     }
 
     public DiscordWebhook setCustomUsername(String username) {
-        this.obj.put("username", username);
+		if (username != null && !username.equals(""))
+			this.obj.put("username", username);
+		else
+		{
+			// unset will allow default discord username to be used (as specified in discord's integration settings)
+			this.obj.remove("username"); 
+		}
         return this;
     }
 
     public DiscordWebhook setCustomAvatarUrl(String url) {
-        this.obj.put("avatar_url", url);
+		if (url != null && !url.equals(""))
+			this.obj.put("avatar_url", url);
+		else
+		{
+			// unset will allow default avatar to be used (as specified in discord's integration settings)
+			this.obj.remove("avatar_url"); 
+		}
         return this;
     }
 


### PR DESCRIPTION
This change allows the discord jenkins pipeline step to set a custom username & avatar url.  

- If not specified, it does not affect the current default.  
- If specified normally, then allows a custom username or avatar url to be used.
- If specified as '', then it prevents username/avatar from being sent to discord so discord's default webhook (configured in integrations panel) can be used.  

This may allow to close https://github.com/jenkinsci/discord-notifier-plugin/issues/20
