### PR TITLE
Fix broken default avatar URL

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
@@ -61,7 +61,7 @@ class DiscordWebhook {
         this.webhookUrl = url;
         this.obj = new JSONObject();
         this.obj.put("username", "Jenkins");
-        this.obj.put("avatar_url", "https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png");
+        this.obj.put("avatar_url", "https://get.jenkins.io/art/jenkins-logo/1024x1024/headshot.png");
         this.embed = new JSONObject();
         this.fields = new JSONArray();
     }


### PR DESCRIPTION
The wiki.jenkins subdomain is deprecated and some of its content is no longer available due it being moved to new locations.
The change proposed is a drop in replacement to restore the icon:

<details>
<summary>Proposed change</summary>

![](https://i.imgur.com/MuaFBwd.png)

</details>

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did