### PR TITLE
Check if client is running before updating proxy settings

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
@@ -201,7 +201,7 @@ class DiscordWebhook {
 
         try {
             final Jenkins instance = Jenkins.getInstanceOrNull();
-            if (instance != null && instance.proxy != null) {
+            if (instance != null && instance.proxy != null && !Unirest.config().isRunning()) {
                 String proxyIP = instance.proxy.name;
                 int proxyPort = instance.proxy.port;
                 if (!proxyIP.equals("")) {


### PR DESCRIPTION
This PR adds a check so the proxy settings of the Unirest client ore only changed if the client is not running

resolves #62

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
