### PR TITLE
chore: use jenkins infra maven cd reusable workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,3 +1,5 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
 name: cd
 on:
   workflow_dispatch:
@@ -6,52 +8,9 @@ on:
       - completed
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
-    steps:
-      - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.0
-        id: verify-ci-status
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output_result: true
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
 
-      - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          name: next
-          tag: next
-          version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.0.0
-        id: interesting-categories
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: needs.validate.outputs.should_release == 'true'
-    steps:
-    - name: Check out
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 8
-    - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}


### PR DESCRIPTION
🤖 Beep boop!

This is an automatic pull request that updates your GitHub action used for continous delivery workflow for this repository.

Switching to using a reusable workflow created to simplify maintance of this file in your repository.

In case of questions, please ping @jetersen.

Additional informations:
[You can find the workflow here](https://github.com/jenkins-infra/github-reusable-workflows/blob/main/.github/workflows/maven-cd.yml)
[Full explaination](https://github.com/jenkinsci/configurationslicing-plugin/pull/117#issuecomment-1156234429)