### PR TITLE
Add Java 17 compatibility, EOL JSR 305 and bump bom baseline

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,12 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.33</version>
+    <version>4.46</version>
     <relativePath />
   </parent>
 
   <name>Discord Notifier</name>
-  <description>Discord Notifier allows you to send Discord embeds about your builds via Discord's webhooks.
-  </description>
-  <url>https://github.com/jenkinsci/discord-notifier-plugin/blob/master/README.md</url>
+  <url>https://github.com/jenkinsci/discord-notifier-plugin</url>
 
   <groupId>nz.co.jammehcow</groupId>
   <artifactId>discord-notifier</artifactId>
@@ -23,13 +21,12 @@
     <revision>1.4.15</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/discord-notifier-plugin</gitHubRepo>
-    <jenkins.version>2.235.1</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.319.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
@@ -38,7 +35,7 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
@@ -73,8 +70,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.235.x</artifactId>
-        <version>918.vae501d2cdc99</version>
+        <artifactId>bom-2.319.x</artifactId>
+        <version>1589.v952386a_7b_85a</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -85,7 +82,7 @@
     <dependency>
       <groupId>com.konghq</groupId>
       <artifactId>unirest-java</artifactId>
-      <version>3.13.6</version>
+      <version>3.13.10</version>
     </dependency>
 
     <!-- for workflow support -->

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordPipelineStep.java
@@ -12,7 +12,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import jenkins.model.JenkinsLocationConfiguration;
 
@@ -267,7 +267,7 @@ public class DiscordPipelineStep extends AbstractStepImpl {
             return "discordSend";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Send an embed message to Webhook URL";

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/WebhookPublisher.java
@@ -1,5 +1,6 @@
 package nz.co.jammehcow.jenkinsdiscord;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -27,6 +28,7 @@ import java.util.Map;
  * Date: 22/04/17.
  */
 
+@SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Requires triage")
 public class WebhookPublisher extends Notifier {
     private final String webhookURL;
     private final String branchName;

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Discord Notifier allows you to send Discord embeds about your builds via Discord's webhooks.
+</div>


### PR DESCRIPTION
The change proposed adds Java 17+ compatibility at compile time, addresses the EOL state of JSR 305, and bumps the baseline to the lowest version bom supports.

Closes #84 
Closes #80 
Closes #72 

cc @KocproZ 