### PR TITLE
Adapt Discord's new markdown feature in artifact set

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/util/EmbedDescription.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/util/EmbedDescription.java
@@ -91,7 +91,7 @@ public class EmbedDescription {
                 this.artifactsList.add("\n*No artifacts saved.*");
             } else {
                 for (Run.Artifact artifact : artifacts) {
-                    this.artifactsList.add(" - " + artifactsURL + artifact.getHref() + "\n");
+                    this.artifactsList.add("- " + artifactsURL + artifact.getHref() + "\n");
                 }
             }
         }


### PR DESCRIPTION
Discord rolled out a new markdown feature. This PR adapts the list of artifacts to consider this new feature, to retain the prior layout.

### Testing done

Before:
![Screenshot 2023-05-25 at 19 37 37](https://github.com/jenkinsci/discord-notifier-plugin/assets/13383509/d7d1fc31-8ed8-48cf-be92-b3a6812ea5bf)
After:
![Screenshot 2023-05-25 at 19 36 29](https://github.com/jenkinsci/discord-notifier-plugin/assets/13383509/0be4353c-cd6c-49fa-bbe0-681b9370c725)