### PR TITLE
Fix crash when saving empty dynamic fields

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DynamicFieldContainer.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DynamicFieldContainer.java
@@ -45,6 +45,10 @@ public class DynamicFieldContainer {
   public static DynamicFieldContainer of(String fieldsString) {
     DynamicFieldContainer fieldContainer = new DynamicFieldContainer();
 
+    if(fieldsString.length() == 0) {
+        return fieldContainer;
+    }
+
     try {
       for (String s : fieldsString.split(",\\s*")) {
         String[] pair = s.split(":", 2);


### PR DESCRIPTION
At some point saving a build configuration started crashing with an `ArrayIndexOutOfBoundsException`.

Fixes #141
Fixes #142

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
