### PR TITLE
Fix #148: Add connection and socket timeouts to prevent indefinite hangs

### DIFF
--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/DiscordWebhook.java
@@ -207,6 +207,10 @@ class DiscordWebhook {
                     Unirest.config().proxy(new Proxy(proxyIP, proxyPort));
                 }
             }
+            
+            // Explicitly set timeouts to prevent hanging plugin execution
+            Unirest.config().connectTimeout(30000).socketTimeout(60000);
+            
             HttpResponse<JsonNode> response;
             if (file != null) {
                 response = Unirest.post(this.webhookUrl)


### PR DESCRIPTION
### Description
This Pull Request fixes the issue where the Jenkins build hangs indefinitely when sending notifications via the Discord Notifier plugin. This typically happens when the Discord API server is unreachable, slow to respond, or closes the connection prematurely.

### Root Cause
The plugin uses the `Unirest` HTTP client without explicit connection or socket timeouts. By default, some configurations of Unirest (or the underlying Apache HttpClient) may wait indefinitely, blocking the Jenkins execution thread.

### Solution
Added explicit timeouts to the `Unirest` configuration in `DiscordWebhook.java`:
- **Connection Timeout**: 30 seconds
- **Socket Timeout**: 60 seconds

These values ensure that the notification attempt fails gracefully with an exception after a reasonable period, allowing the Jenkins build to proceed or fail as per its own configuration, rather than hanging.

### Verification
- Tested locally by simulating a non-responsive socket server.
- Verified that the plugin now throws a timeout exception instead of hanging.
- Verified successful message delivery to an actual Discord Webhook after applying the fix.
- Tested on Jenkins LTS version 2.555.1.

Fixes #148