### PR TITLE
Plugin throws a ClassNotFoundException for org.json.JSONObject, failing entirely

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20231013</version>
+      <version>20231013-3.v20f3c247f2fe</version>
     </dependency>
 
     <!-- for workflow support -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20231013-3.v20f3c247f2fe</version>
+      <version>20251224</version>
     </dependency>
 
     <!-- for workflow support -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>json-api</artifactId>
-      <version>20231013-3.v20f3c247f2fe</version>
+      <version>20251224-185.v0cc18490c62c</version>
     </dependency>
 
     <!-- for workflow support -->

--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>json-api</artifactId>
-      <version>20251224-185.v0cc18490c62c</version>
     </dependency>
 
     <!-- for workflow support -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
       <version>3.14.5</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20231013</version>
+    </dependency>
+
     <!-- for workflow support -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20251224</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>json-api</artifactId>
+      <version>20231013-3.v20f3c247f2fe</version>
     </dependency>
 
     <!-- for workflow support -->


### PR DESCRIPTION
## Description
This Pull Request fixes the issue where the Discord Notifier plugin throws a `ClassNotFoundException` for `org.json.JSONObject` on newer Jenkins versions, causing Discord notifications to fail entirely.

## Root Cause
The plugin depends on `org.json.JSONObject` and `org.json.JSONArray` without explicitly declaring `org.json` as a dependency in `pom.xml`. Previously this worked because `org.json` was incidentally available through Jenkins core or another plugin's classloader. Following Jenkins updates, `org.json` was moved into a dedicated `json-api` plugin with an isolated classloader, making it no longer accessible to plugins that did not explicitly declare it as a dependency.

## Solution
Added an explicit dependency on the `json-api` Jenkins plugin in `pom.xml`:

- Declared `org.jenkins-ci.plugins:json-api:20231013-3.v20f3c247f2fe` as a plugin dependency instead of bundling `org.json` directly
- This lets Jenkins manage the classloader wiring correctly, avoiding potential classpath conflicts from bundling the library directly into the plugin JAR
- Jenkins will automatically install or update `json-api` alongside `discord-notifier` if not already present

```xml

    org.jenkins-ci.plugins
    json-api
    20231013-3.v20f3c247f2fe

```

## Verification

- Confirmed the root cause by verifying `discord-notifier` classloader could not access `org.json` via Jenkins Script Console
- Built the plugin locally with the added dependency using `mvn clean package`
- Installed the resulting `.hpi` on Jenkins and verified via Script Console that `org.json` is now accessible to the plugin's classloader
- Verified successful Discord notification delivery on a real Jenkins job
- Tested on Jenkins LTS version 2.555.1