### PR TITLE
Fix class not found exception

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 buildPlugin(
         useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
         configurations: [
-                [platform: 'linux', jdk: 21],
-                [platform: 'windows', jdk: 17],
+                [platform: 'linux', jdk: 25],
+                [platform: 'windows', jdk: 21],
         ])

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>json-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.konghq</groupId>
       <artifactId>unirest-java</artifactId>
       <version>3.14.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/discord-notifier-plugin</gitHubRepo>
-    <jenkins.version>2.401.3</jenkins.version>
+    <jenkins.baseline>2.528</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>
   </properties>
@@ -70,8 +71,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
-        <version>2745.vc7b_fe4c876fa_</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>6364.v16b_76a_4023c7</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -79,6 +80,22 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>provided</scope> <!-- core provides it -->
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.konghq</groupId>
       <artifactId>unirest-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>
+    <hpi.bundledArtifacts>unirest-java</hpi.bundledArtifacts>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.87</version>
+    <version>6.2153.vcf31911d10c4</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Fix class not found exception

Fixes #148

Also fixes https://github.com/jenkinsci/echarts-api-plugin/issues/500

Also includes changes to:

* Test with Java 25 and Java 21

  Java 25 released September 16, 2025.  Jenkins core (weekly) has supported Java 25 since Jenkins 2.534, Oct 28, 2025.  Jenkins core (LTS) has supported Java 25 since 2.541.1, Jan 21, 2026.  95% of the 300 most popular plugins now compile and test with Java 25.

  Removes the testing of Java 17 because we continue to generate Java 17 byte code from the Java 21 and Java 25 compilers and have found no issues with the generated byte code.  The plugin continues to support Java 17 until it is upgraded to require a Jenkins version that drops Java 17 support, like the 2.555.1 LTS or the 2.545 weekly.

* Declare dependencies explicitly

  Avoid accidental declaration of new dependencies

* Require Jenkins 2.528.3 or newer

  https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ recommends either 2.528.3 or 2.541.3.  I chose the older of the two to support more users.

  Declares explicit dependencies on API plugins rather than bundling the jar files for those dependencies as transitive dependencies of unirest-java.

### Testing done

* Confirmed that the plugin compiles and passes tests with Java 25
* Used replay on ci.jenkins.io to execute the modified Jenkinsfile

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
