### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <gitHubRepo>jenkinsci/discord-notifier-plugin</gitHubRepo>
     <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>
     <hpi.bundledArtifacts>unirest-java</hpi.bundledArtifacts>

--- a/src/main/java/nz/co/jammehcow/jenkinsdiscord/util/EmbedDescription.java
+++ b/src/main/java/nz/co/jammehcow/jenkinsdiscord/util/EmbedDescription.java
@@ -12,7 +12,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import hudson.Util;
 
 /**
  * @author jammehcow
@@ -36,7 +36,7 @@ public class EmbedDescription {
             String scmWebUrl
     ) {
         String artifactsURL = globalConfig.getUrl() + build.getUrl() + "artifact/";
-        this.prefix = StringUtils.trimToNull(prefix);
+        this.prefix = Util.fixEmptyAndTrim(prefix);
 
         if (showChangeset) {
             ArrayList<Object> changes = new ArrayList<>();


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringUtils.trimToNull(prefix)` becomes `Util.fixEmptyAndTrim(prefix)`. The Jenkins helper has
exactly the same contract — trim, then null if the result is empty — so the surrounding null checks are
unchanged. Also enables the `ban-commons-lang-2` enforcer rule.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
